### PR TITLE
Image/gpx correlation : Add choice to Use gps time

### DIFF
--- a/src/org/openstreetmap/josm/data/gpx/GpxImageCorrelation.java
+++ b/src/org/openstreetmap/josm/data/gpx/GpxImageCorrelation.java
@@ -75,7 +75,7 @@ public final class GpxImageCorrelation {
         final GpxImageDirectionPositionSettings dirpos = settings.getDirectionPositionSettings();
         final GpxImageExtendedSettings extSettings = settings.getExtendedSettings();
         final long offset = settings.getOffset();
-        final String imgTimeSource = settings.getImgTimeSource();
+        final TimeSource imgTimeSource = settings.getImgTimeSource();
 
         boolean isFirst = true;
         long prevWpTime = 0;
@@ -304,7 +304,7 @@ public final class GpxImageCorrelation {
         return null;
     }
 
-    private static int matchPoints(List<? extends GpxImageEntry> images, WayPoint prevWp, long prevWpTime, WayPoint curWp, long curWpTime, String imgTimeSource,
+    private static int matchPoints(List<? extends GpxImageEntry> images, WayPoint prevWp, long prevWpTime, WayPoint curWp, long curWpTime, TimeSource imgTimeSource,
             long offset, boolean interpolate, int tagTime, WayPoint nextWp, GpxImageDirectionPositionSettings dirpos, GpxImageExtendedSettings extSetting) {
 
         final boolean isLast = nextWp == null;
@@ -505,7 +505,7 @@ public final class GpxImageCorrelation {
         return (Utils.toDegrees(direction) + angleOffset) % 360d;
     }
 
-    private static int getLastIndexOfListBefore(List<? extends GpxImageEntry> images, long searchedTime, String imgTimeSource) {
+    private static int getLastIndexOfListBefore(List<? extends GpxImageEntry> images, long searchedTime, TimeSource imgTimeSource) {
         int lstSize = images.size();
 
         // No photos or the first photo taken is later than the search period

--- a/src/org/openstreetmap/josm/data/gpx/GpxImageCorrelationSettings.java
+++ b/src/org/openstreetmap/josm/data/gpx/GpxImageCorrelationSettings.java
@@ -11,6 +11,7 @@ public class GpxImageCorrelationSettings {
 
     private final long offset;
     private final boolean forceTags;
+    private final String imgTimeSource;
     private final GpxImageDirectionPositionSettings directionPositionSettings;
     private final GpxImageExtendedSettings extendedSettings;
 
@@ -20,7 +21,7 @@ public class GpxImageCorrelationSettings {
      * @param forceTags force tagging of all photos, otherwise prefs are used
      */
     public GpxImageCorrelationSettings(long offset, boolean forceTags) {
-        this(offset, forceTags,
+        this(offset, forceTags, "exifCamTime",
         new GpxImageDirectionPositionSettings(false, 0, false, 0, 0, 0),
         new GpxImageExtendedSettings(false, null)
         );
@@ -30,11 +31,29 @@ public class GpxImageCorrelationSettings {
      * Constructs a new {@code GpxImageCorrelationSettings}.
      * @param offset offset in milliseconds
      * @param forceTags force tagging of all photos, otherwise prefs are used
+     * @param imgTimeSource select image clock source: 
+     * "exifCamTime" for camera internal clock
+     * "exifGpsTime for the gps clock of the camera
+     */
+    public GpxImageCorrelationSettings(long offset, boolean forceTags, String imgTimeSource) {
+        this(offset, forceTags, imgTimeSource,
+        new GpxImageDirectionPositionSettings(false, 0, false, 0, 0, 0),
+        new GpxImageExtendedSettings(false, null)
+        );
+    }
+
+    /**
+     * Constructs a new {@code GpxImageCorrelationSettings}.
+     * @param offset offset in milliseconds
+     * @param forceTags force tagging of all photos, otherwise prefs are used
+     * @param imgTimeSource select image clock source: 
+     * "exifCamTime" for camera internal clock
+     * "exifGpsTime for the gps clock of the camera
      * @param directionPositionSettings direction/position settings
      */
-    public GpxImageCorrelationSettings(long offset, boolean forceTags,
+    public GpxImageCorrelationSettings(long offset, boolean forceTags, String imgTimeSource,
             GpxImageDirectionPositionSettings directionPositionSettings) {
-        this(offset, forceTags, directionPositionSettings,
+        this(offset, forceTags, imgTimeSource, directionPositionSettings,
         new GpxImageExtendedSettings(false, null));
     }
 
@@ -42,14 +61,18 @@ public class GpxImageCorrelationSettings {
      * Constructs a new {@code GpxImageCorrelationSettings}.
      * @param offset offset in milliseconds
      * @param forceTags force tagging of all photos, otherwise prefs are used
+     * @param imgTimeSource select image clock source: 
+     * "exifCamTime" for camera internal clock
+     * "exifGpsTime for the gps clock of the camera
      * @param directionPositionSettings direction/position settings
      * @param extendedSettings blablabla
      */
-    public GpxImageCorrelationSettings(long offset, boolean forceTags,
+    public GpxImageCorrelationSettings(long offset, boolean forceTags, String imgTimeSource,
             GpxImageDirectionPositionSettings directionPositionSettings,
             GpxImageExtendedSettings extendedSettings) {
         this.offset = offset;
         this.forceTags = forceTags;
+        this.imgTimeSource = imgTimeSource;
         this.directionPositionSettings = Objects.requireNonNull(directionPositionSettings);
         this.extendedSettings = Objects.requireNonNull(extendedSettings);
     }
@@ -67,6 +90,15 @@ public class GpxImageCorrelationSettings {
      */
     public boolean isForceTags() {
         return forceTags;
+    }
+
+    /**
+     * Return the selected image clock source
+     * @return the clock source
+     * @since xxx
+     */
+    public String getImgTimeSource() {
+        return imgTimeSource;
     }
 
     /**
@@ -88,6 +120,7 @@ public class GpxImageCorrelationSettings {
     @Override
     public String toString() {
         return "[offset=" + offset + ", forceTags=" + forceTags
+                + ", clock source=" + imgTimeSource
                 + ", directionPositionSettings=" + directionPositionSettings
                 + ", extendedSettings=" + extendedSettings + ']';
     }

--- a/src/org/openstreetmap/josm/data/gpx/GpxImageCorrelationSettings.java
+++ b/src/org/openstreetmap/josm/data/gpx/GpxImageCorrelationSettings.java
@@ -11,7 +11,7 @@ public class GpxImageCorrelationSettings {
 
     private final long offset;
     private final boolean forceTags;
-    private final String imgTimeSource;
+    private final TimeSource imgTimeSource;
     private final GpxImageDirectionPositionSettings directionPositionSettings;
     private final GpxImageExtendedSettings extendedSettings;
 
@@ -21,7 +21,7 @@ public class GpxImageCorrelationSettings {
      * @param forceTags force tagging of all photos, otherwise prefs are used
      */
     public GpxImageCorrelationSettings(long offset, boolean forceTags) {
-        this(offset, forceTags, "exifCamTime",
+        this(offset, forceTags, TimeSource.EXIFCAMTIME,
         new GpxImageDirectionPositionSettings(false, 0, false, 0, 0, 0),
         new GpxImageExtendedSettings(false, null)
         );
@@ -35,7 +35,7 @@ public class GpxImageCorrelationSettings {
      * "exifCamTime" for camera internal clock
      * "exifGpsTime for the gps clock of the camera
      */
-    public GpxImageCorrelationSettings(long offset, boolean forceTags, String imgTimeSource) {
+    public GpxImageCorrelationSettings(long offset, boolean forceTags, TimeSource imgTimeSource) {
         this(offset, forceTags, imgTimeSource,
         new GpxImageDirectionPositionSettings(false, 0, false, 0, 0, 0),
         new GpxImageExtendedSettings(false, null)
@@ -51,7 +51,7 @@ public class GpxImageCorrelationSettings {
      * "exifGpsTime for the gps clock of the camera
      * @param directionPositionSettings direction/position settings
      */
-    public GpxImageCorrelationSettings(long offset, boolean forceTags, String imgTimeSource,
+    public GpxImageCorrelationSettings(long offset, boolean forceTags, TimeSource imgTimeSource,
             GpxImageDirectionPositionSettings directionPositionSettings) {
         this(offset, forceTags, imgTimeSource, directionPositionSettings,
         new GpxImageExtendedSettings(false, null));
@@ -67,7 +67,7 @@ public class GpxImageCorrelationSettings {
      * @param directionPositionSettings direction/position settings
      * @param extendedSettings blablabla
      */
-    public GpxImageCorrelationSettings(long offset, boolean forceTags, String imgTimeSource,
+    public GpxImageCorrelationSettings(long offset, boolean forceTags, TimeSource imgTimeSource,
             GpxImageDirectionPositionSettings directionPositionSettings,
             GpxImageExtendedSettings extendedSettings) {
         this.offset = offset;
@@ -97,7 +97,7 @@ public class GpxImageCorrelationSettings {
      * @return the clock source
      * @since xxx
      */
-    public String getImgTimeSource() {
+    public TimeSource getImgTimeSource() {
         return imgTimeSource;
     }
 

--- a/src/org/openstreetmap/josm/data/gpx/GpxImageEntry.java
+++ b/src/org/openstreetmap/josm/data/gpx/GpxImageEntry.java
@@ -357,6 +357,22 @@ public class GpxImageEntry implements Comparable<GpxImageEntry>, IQuadBucketType
         return exifGpsTime != null;
     }
 
+    /**
+     * Return the time value selected with the parameter.
+     * @param the wanted time value, exifCamTime or exifGpsTime
+     * @return exifInstant or exifGpsInstant
+     * @since xxx
+     */
+    @Override
+    public Instant getThisInstant(String timeSource) {
+        if (timeSource.equals("exifGpsTime")) {
+            return getExifGpsInstant();
+        } else if (timeSource.equals("exifCamTime")) {
+            return getExifInstant();
+        }
+        return null;
+    }
+
     private static Date getDefensiveDate(Instant date) {
         if (date == null)
             return null;

--- a/src/org/openstreetmap/josm/data/gpx/GpxImageEntry.java
+++ b/src/org/openstreetmap/josm/data/gpx/GpxImageEntry.java
@@ -360,15 +360,16 @@ public class GpxImageEntry implements Comparable<GpxImageEntry>, IQuadBucketType
     /**
      * Return the time value selected with the parameter.
      * @param the wanted time value, exifCamTime or exifGpsTime
-     * @return exifInstant or exifGpsInstant
+     * @return exifInstant or exifGpsInstant value
      * @since xxx
      */
     @Override
-    public Instant getThisInstant(String timeSource) {
-        if (timeSource.equals("exifGpsTime")) {
-            return getExifGpsInstant();
-        } else if (timeSource.equals("exifCamTime")) {
-            return getExifInstant();
+    public Instant getThisInstant(TimeSource timeSource) {
+        switch (timeSource) {
+            case EXIFGPSTIME:
+                return getExifGpsInstant();
+            case EXIFCAMTIME:
+                return getExifInstant();
         }
         return null;
     }

--- a/src/org/openstreetmap/josm/data/gpx/TimeSource.java
+++ b/src/org/openstreetmap/josm/data/gpx/TimeSource.java
@@ -1,0 +1,13 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.data.gpx;
+
+/**
+ * Time sources available in the image Exif metadata.
+ * @since xxx
+ */
+public enum TimeSource {
+    /**Time from the camera internal clock (RTC)*/
+    EXIFCAMTIME,
+    /**Time from the camera gps clock*/
+    EXIFGPSTIME
+}

--- a/src/org/openstreetmap/josm/data/imagery/street_level/IImageEntry.java
+++ b/src/org/openstreetmap/josm/data/imagery/street_level/IImageEntry.java
@@ -305,6 +305,13 @@ public interface IImageEntry<I extends IImageEntry<I>> {
     Instant getGpsInstant();
 
     /**
+     * Returns the Exif GPS Time value. The Exif GPS time value from the temporary copy
+     * is returned if that copy exists.
+     * @return the Exif GPS time value
+     */
+    Instant getExifGpsInstant();
+    
+    /**
      * Returns the IPTC caption.
      * @return the IPTC caption
      */

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/CorrelateGpxWithImages.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/CorrelateGpxWithImages.java
@@ -647,7 +647,7 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
         // (html ?) See https://stackoverflow.com/questions/868651/multi-line-tooltips-in-java
         tfDatum.setToolTipText(tr("Enter the datum for your images coordinates. Default value is WGS-84." +
                                 " For RTK it could be your local CRS epsg code." +
-                                " (e.g. EPSG:9777 for France mainland.)"));
+                                " (e.g. EPSG:9781 for France mainland.)"));
         tfDatum.setEnabled(false);
 
         gbc = GBC.eol();

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/CorrelateGpxWithImages.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/CorrelateGpxWithImages.java
@@ -5,6 +5,7 @@ import static org.openstreetmap.josm.tools.I18n.tr;
 import static org.openstreetmap.josm.tools.I18n.trn;
 
 import java.awt.BorderLayout;
+import java.awt.Button;
 import java.awt.Cursor;
 import java.awt.FlowLayout;
 import java.awt.Font;
@@ -32,12 +33,14 @@ import java.util.function.Consumer;
 
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
+import javax.swing.ButtonGroup;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JRadioButton;
 import javax.swing.JSeparator;
 import javax.swing.SwingConstants;
 import javax.swing.event.ChangeEvent;
@@ -88,6 +91,7 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
 
     private static JosmComboBoxModel<GpxDataWrapper> gpxModel;
     private static boolean forceTags;
+    private static String imgTimeSource;
 
     private final transient GeoImageLayer yLayer;
     private transient CorrelationSupportLayer supportLayer;
@@ -249,6 +253,8 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
     private JButton buttonSupport;
     private JosmTextField tfTimezone;
     private JosmTextField tfOffset;
+    private JRadioButton rbTimeFromCamera;
+    private JRadioButton rbTimeFromGps;
     private JCheckBox cbExifImg;
     private JCheckBox cbTaggedImg;
     private JCheckBox cbShowThumbs;
@@ -517,6 +523,14 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
         tfOffset = new JosmTextField(10);
         tfOffset.setText(delta.formatOffset());
 
+        //Time/Clock source choice 
+        rbTimeFromCamera = new JRadioButton(tr("Camera clock"));
+        rbTimeFromCamera.setSelected(true);
+        rbTimeFromGps = new JRadioButton(tr("Camera Gps clock"));        
+        ButtonGroup timeSourceGroup = new ButtonGroup();
+        timeSourceGroup.add(rbTimeFromCamera);
+        timeSourceGroup.add(rbTimeFromGps);
+
         JButton buttonViewGpsPhoto = new JButton(tr("<html>Use photo of an accurate clock,<br>e.g. GPS receiver display</html>"));
         buttonViewGpsPhoto.setIcon(ImageProvider.get("clock"));
         buttonViewGpsPhoto.addActionListener(new SetOffsetActionListener());
@@ -602,6 +616,22 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
 
         gbc.gridx = 3;
         panelTf.add(buttonAdjust, gbc);
+
+        // Image time source choice
+        gbc = GBC.eol();
+        gbc.gridx = 0;
+        gbc.gridy = y++;
+        panelTf.add(new JLabel(tr("Image time source:")), gbc);
+
+        gbc = GBC.eol();
+        gbc.gridx = 1;
+        gbc.gridy = y++;
+        panelTf.add(rbTimeFromCamera, gbc);
+
+        gbc = GBC.eol();
+        gbc.gridx = 1;
+        gbc.gridy = y++;
+        panelTf.add(rbTimeFromGps, gbc);
 
         gbc = GBC.eol().fill(GridBagConstraints.HORIZONTAL).insets(0, 12, 0, 0);
         gbc.gridx = 0;
@@ -700,6 +730,8 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
 
         tfTimezone.getDocument().addDocumentListener(statusBarUpdater);
         tfOffset.getDocument().addDocumentListener(statusBarUpdater);
+        rbTimeFromCamera.addItemListener(statusBarUpdaterWithRepaint);
+        rbTimeFromGps.addItemListener(statusBarUpdaterWithRepaint);
         cbExifImg.addItemListener(statusBarUpdaterWithRepaint);
         cbTaggedImg.addItemListener(statusBarUpdaterWithRepaint);
         cbAddGpsDatum.addItemListener(statusBarUpdaterWithRepaint);
@@ -833,6 +865,13 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
                 return e.getMessage();
             }
 
+            // Set image time source from the radio button status
+            if (rbTimeFromGps.isSelected()) {
+                imgTimeSource = "exifGpsTime";
+            } else {
+                imgTimeSource = "exifCamTime";
+            }
+            
             // The selection of images we are about to correlate may have changed.
             // So reset all images.
             yLayer.discardTmp();
@@ -849,7 +888,7 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
             final long offsetMs = ((long) (timezone.getHours() * TimeUnit.HOURS.toMillis(1))) + delta.getMilliseconds(); // in milliseconds
             lastNumMatched = GpxImageCorrelation.matchGpxTrack(dateImgLst, selGpx.data,
                     pDirectionPosition.isVisible() ?
-                            new GpxImageCorrelationSettings(offsetMs, forceTags, pDirectionPosition.getSettings(), new GpxImageExtendedSettings(cbAddGpsDatum.isSelected(), tfDatum.getText())) :
+                            new GpxImageCorrelationSettings(offsetMs, forceTags, imgTimeSource, pDirectionPosition.getSettings(), new GpxImageExtendedSettings(cbAddGpsDatum.isSelected(), tfDatum.getText())) :
                             new GpxImageCorrelationSettings(offsetMs, forceTags));
 
             return trn("<html>Matched <b>{0}</b> of <b>{1}</b> photo to GPX track.</html>",

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/CorrelateGpxWithImages.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/CorrelateGpxWithImages.java
@@ -59,6 +59,7 @@ import org.openstreetmap.josm.data.gpx.GpxImageCorrelationSettings;
 import org.openstreetmap.josm.data.gpx.GpxImageExtendedSettings;
 import org.openstreetmap.josm.data.gpx.GpxTimeOffset;
 import org.openstreetmap.josm.data.gpx.GpxTimezone;
+import org.openstreetmap.josm.data.gpx.TimeSource;
 import org.openstreetmap.josm.data.gpx.WayPoint;
 import org.openstreetmap.josm.data.osm.visitor.BoundingXYVisitor;
 import org.openstreetmap.josm.gui.ExtendedDialog;
@@ -91,7 +92,7 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
 
     private static JosmComboBoxModel<GpxDataWrapper> gpxModel;
     private static boolean forceTags;
-    private static String imgTimeSource;
+    private static TimeSource imgTimeSource;
 
     private final transient GeoImageLayer yLayer;
     private transient CorrelationSupportLayer supportLayer;
@@ -867,9 +868,9 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
 
             // Set image time source from the radio button status
             if (rbTimeFromGps.isSelected()) {
-                imgTimeSource = "exifGpsTime";
+                imgTimeSource = TimeSource.EXIFGPSTIME;
             } else {
-                imgTimeSource = "exifCamTime";
+                imgTimeSource = TimeSource.EXIFCAMTIME;
             }
             
             // The selection of images we are about to correlate may have changed.

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/EditImagesSequenceAction.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/EditImagesSequenceAction.java
@@ -82,7 +82,7 @@ public class EditImagesSequenceAction extends JosmAction {
             // Create a temporary copy for each image
             dateImgLst.forEach(ie -> ie.createTmp().unflagNewGpsData());
             GpxImageCorrelation.matchGpxTrack(dateImgLst, yLayer.getFauxGpxData(),
-                            new GpxImageCorrelationSettings(0, false, pDirectionPosition.getSettings()));
+                            new GpxImageCorrelationSettings(0, false, "exifCamTime", pDirectionPosition.getSettings()));
             yLayer.updateBufferAndRepaint();
         }
     }

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/EditImagesSequenceAction.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/EditImagesSequenceAction.java
@@ -16,6 +16,7 @@ import javax.swing.event.ChangeListener;
 import org.openstreetmap.josm.actions.JosmAction;
 import org.openstreetmap.josm.data.gpx.GpxImageCorrelation;
 import org.openstreetmap.josm.data.gpx.GpxImageCorrelationSettings;
+import org.openstreetmap.josm.data.gpx.TimeSource;
 import org.openstreetmap.josm.gui.ExtendedDialog;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.layer.geoimage.CorrelateGpxWithImages.RepaintTheMapListener;
@@ -82,7 +83,7 @@ public class EditImagesSequenceAction extends JosmAction {
             // Create a temporary copy for each image
             dateImgLst.forEach(ie -> ie.createTmp().unflagNewGpsData());
             GpxImageCorrelation.matchGpxTrack(dateImgLst, yLayer.getFauxGpxData(),
-                            new GpxImageCorrelationSettings(0, false, "exifCamTime", pDirectionPosition.getSettings()));
+                            new GpxImageCorrelationSettings(0, false, TimeSource.EXIFCAMTIME, pDirectionPosition.getSettings()));
             yLayer.updateBufferAndRepaint();
         }
     }

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/ImageMetadata.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/ImageMetadata.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.openstreetmap.josm.data.coor.ILatLon;
 import org.openstreetmap.josm.data.imagery.street_level.Projections;
+import org.openstreetmap.josm.data.gpx.TimeSource;
 
 /**
  * An interface for images with metadata
@@ -119,7 +120,7 @@ public interface ImageMetadata {
      * Get camera or gps exif time
      * @return the choosen time
      */
-    Instant getThisInstant(String timeSource);
+    Instant getThisInstant(TimeSource timeSource);
 
     /**
      * Get the exif coordinates

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/ImageMetadata.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/ImageMetadata.java
@@ -116,6 +116,12 @@ public interface ImageMetadata {
     boolean hasExifGpsTime();
 
     /**
+     * Get camera or gps exif time
+     * @return the choosen time
+     */
+    Instant getThisInstant(String timeSource);
+
+    /**
      * Get the exif coordinates
      * @return The location of the image
      */

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/ImageViewerDialog.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/ImageViewerDialog.java
@@ -1030,11 +1030,15 @@ public final class ImageViewerDialog extends ToggleDialog implements LayerChange
                 .withZone(ZoneOffset.UTC);
 
         if (entry.hasExifTime()) {
-            osd.append(tr("\nEXIF time: {0}", dtf.format(entry.getExifInstant())));
+            osd.append(tr("\nEXIF cam time: {0}", dtf.format(entry.getExifInstant())));
+        }
+        if (entry.getExifGpsInstant() != null) {
+            osd.append(tr("\nEXIF gps time: {0}", dtf.format(entry.getExifGpsInstant())));
         }
         if (entry.hasGpsTime()) {
-            osd.append(tr("\nGPS time: {0}", dtf.format(entry.getGpsInstant())));
+            osd.append(tr("\nGPS time:      {0}", dtf.format(entry.getGpsInstant())));
         }
+
         Optional.ofNullable(entry.getIptcCaption()).map(s -> tr("\nCaption: {0}", s)).ifPresent(osd::append);
         Optional.ofNullable(entry.getIptcHeadline()).map(s -> tr("\nHeadline: {0}", s)).ifPresent(osd::append);
         Optional.ofNullable(entry.getIptcKeywords()).map(s -> tr("\nKeywords: {0}", s)).ifPresent(osd::append);

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/RemoteEntry.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/RemoteEntry.java
@@ -326,6 +326,11 @@ public class RemoteEntry implements IImageEntry<RemoteEntry>, ImageMetadata {
     }
 
     @Override
+    public Instant getThisInstant(String timeSource) {
+        return this.getThisInstant(timeSource);
+    }
+    
+    @Override
     public ILatLon getExifCoor() {
         return this.exifCoor;
     }

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/RemoteEntry.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/RemoteEntry.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.openstreetmap.josm.data.coor.ILatLon;
+import org.openstreetmap.josm.data.gpx.TimeSource;
 import org.openstreetmap.josm.data.imagery.street_level.IImageEntry;
 import org.openstreetmap.josm.data.imagery.street_level.Projections;
 import org.openstreetmap.josm.tools.HttpClient;
@@ -326,7 +327,7 @@ public class RemoteEntry implements IImageEntry<RemoteEntry>, ImageMetadata {
     }
 
     @Override
-    public Instant getThisInstant(String timeSource) {
+    public Instant getThisInstant(TimeSource timeSource) {
         return this.getThisInstant(timeSource);
     }
     

--- a/src/org/openstreetmap/josm/tools/ExifReader.java
+++ b/src/org/openstreetmap/josm/tools/ExifReader.java
@@ -126,6 +126,40 @@ public final class ExifReader {
     }
 
     /**
+     * Returns the gps date/time from the given JPEG file.
+     * @param filename The JPEG file to read
+     * @return The gps date/time read in the EXIF section, or {@code null} if not found
+     * @since xxx
+     */
+    public static Instant readGpsInstant(File filename) {
+        try {
+            final Metadata metadata = JpegMetadataReader.readMetadata(filename);
+            final GpsDirectory dirGps = metadata.getFirstDirectoryOfType(GpsDirectory.class);
+            return readGpsInstant(dirGps);
+        } catch (JpegProcessingException | IOException e) {
+            Logging.error(e);
+        }
+        return null;
+    }
+
+    /**
+     * Returns the gps date/time from the given JPEG file.
+     * @param dirGps The EXIF GPS directory
+     * @return The gps date/time read in the EXIF section, or {@code null} if not found
+     */
+    public static Instant readGpsInstant(GpsDirectory dirGps) {
+        if (dirGps != null) {
+            try {
+                Instant dateTimeStamp = dirGps.getGpsDate().toInstant();
+                return dateTimeStamp;
+            } catch (UncheckedParseException | DateTimeException e) {
+                Logging.error(e);
+            }
+        }
+        return null;
+    }
+
+    /**
      * Returns the image orientation of the given JPEG file.
      * @param filename The JPEG file to read
      * @return The image orientation as an {@code int}. Default value is 1. Possible values are listed in EXIF spec as follows:<br><ol>

--- a/test/unit/org/openstreetmap/josm/tools/ExifReaderTest.java
+++ b/test/unit/org/openstreetmap/josm/tools/ExifReaderTest.java
@@ -56,6 +56,12 @@ class ExifReaderTest {
         assertEquals(Instant.parse(expectedDate), date);
     }
 
+    @Test
+    void testReadGpsDateTime() {
+        Instant date = ExifReader.readGpsInstant(positionErrorSampleFile);
+        assertEquals(Instant.parse("2024-04-30T16:36:42Z"), date);
+    }
+
     /**
      * Test orientation extraction
      */


### PR DESCRIPTION
When correlating images with gpx track, the timestamp used for the images is usually exif DateTimeOriginal. This Pull request let the user to choose the exif Gps time.

![image](https://github.com/user-attachments/assets/02a4fc36-792f-46fa-81da-e4e3f7ce8903)
