### PR TITLE
Filter exif gps time image

### DIFF
--- a/src/org/openstreetmap/josm/gui/layer/geoimage/CorrelateGpxWithImages.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/CorrelateGpxWithImages.java
@@ -551,9 +551,9 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
 
         JLabel labelPosition = new JLabel(tr("Override position for: "));
 
-        int numAll = yLayer.getSortedImgList(true, true).size();
-        int numExif = numAll - yLayer.getSortedImgList(false, true).size();
-        int numTagged = numAll - yLayer.getSortedImgList(true, false).size();
+        int numAll = yLayer.getSortedImgList(true, true, rbTimeFromGps.isSelected()).size();
+        int numExif = numAll - yLayer.getSortedImgList(false, true, rbTimeFromGps.isSelected()).size();
+        int numTagged = numAll - yLayer.getSortedImgList(true, false, rbTimeFromGps.isSelected()).size();
 
         cbExifImg = new JCheckBox(tr("Images with geo location in exif data ({0}/{1})", numExif, numAll));
         cbExifImg.setEnabled(numExif != 0);
@@ -828,6 +828,9 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
             // So reset all images.
             yLayer.discardTmp();
 
+            //Get how many images are present in the layer
+            int totalImg = yLayer.getImages().size();
+            
             // Construct a list of images that have a date, and sort them on the date.
             List<ImageEntry> dateImgLst = getSortedImgList();
             // Create a temporary copy for each image
@@ -846,7 +849,7 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
 
             return trn("<html>Matched <b>{0}</b> of <b>{1}</b> photo to GPX track.</html>",
                     "<html>Matched <b>{0}</b> of <b>{1}</b> photos to GPX track.</html>",
-                    dateImgLst.size(), lastNumMatched, dateImgLst.size());
+                    totalImg, lastNumMatched, totalImg);
         }
     }
 
@@ -1003,7 +1006,7 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
     }
 
     private List<ImageEntry> getSortedImgList() {
-        return yLayer.getSortedImgList(cbExifImg.isSelected(), cbTaggedImg.isSelected());
+        return yLayer.getSortedImgList(cbExifImg.isSelected(), cbTaggedImg.isSelected(), rbTimeFromGps.isSelected());
     }
 
     private static GpxDataWrapper selectedGPX(boolean complain) {

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/CorrelateGpxWithImages.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/CorrelateGpxWithImages.java
@@ -551,9 +551,9 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
 
         JLabel labelPosition = new JLabel(tr("Override position for: "));
 
-        int numAll = yLayer.getSortedImgList(true, true, rbTimeFromGps.isSelected()).size();
-        int numExif = numAll - yLayer.getSortedImgList(false, true, rbTimeFromGps.isSelected()).size();
-        int numTagged = numAll - yLayer.getSortedImgList(true, false, rbTimeFromGps.isSelected()).size();
+        int numAll = yLayer.getSortedImgList(true, true, imgTimeSource).size();
+        int numExif = numAll - yLayer.getSortedImgList(false, true, imgTimeSource).size();
+        int numTagged = numAll - yLayer.getSortedImgList(true, false, imgTimeSource).size();
 
         cbExifImg = new JCheckBox(tr("Images with geo location in exif data ({0}/{1})", numExif, numAll));
         cbExifImg.setEnabled(numExif != 0);
@@ -1006,7 +1006,7 @@ public class CorrelateGpxWithImages extends AbstractAction implements ExpertMode
     }
 
     private List<ImageEntry> getSortedImgList() {
-        return yLayer.getSortedImgList(cbExifImg.isSelected(), cbTaggedImg.isSelected(), rbTimeFromGps.isSelected());
+        return yLayer.getSortedImgList(cbExifImg.isSelected(), cbTaggedImg.isSelected(), imgTimeSource);
     }
 
     private static GpxDataWrapper selectedGPX(boolean complain) {

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/EditImagesSequenceAction.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/EditImagesSequenceAction.java
@@ -79,7 +79,7 @@ public class EditImagesSequenceAction extends JosmAction {
             // So reset all images.
             yLayer.discardTmp();
             // Construct a list of images that have a date, and sort them on the date.
-            List<ImageEntry> dateImgLst = yLayer.getSortedImgList(true, true);
+            List<ImageEntry> dateImgLst = yLayer.getSortedImgList(true, true, false);
             // Create a temporary copy for each image
             dateImgLst.forEach(ie -> ie.createTmp().unflagNewGpsData());
             GpxImageCorrelation.matchGpxTrack(dateImgLst, yLayer.getFauxGpxData(),

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/EditImagesSequenceAction.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/EditImagesSequenceAction.java
@@ -79,7 +79,7 @@ public class EditImagesSequenceAction extends JosmAction {
             // So reset all images.
             yLayer.discardTmp();
             // Construct a list of images that have a date, and sort them on the date.
-            List<ImageEntry> dateImgLst = yLayer.getSortedImgList(true, true, false);
+            List<ImageEntry> dateImgLst = yLayer.getSortedImgList(true, true, TimeSource.EXIFCAMTIME);
             // Create a temporary copy for each image
             dateImgLst.forEach(ie -> ie.createTmp().unflagNewGpsData());
             GpxImageCorrelation.matchGpxTrack(dateImgLst, yLayer.getFauxGpxData(),

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/GeoImageLayer.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/GeoImageLayer.java
@@ -987,8 +987,8 @@ public class GeoImageLayer extends AbstractModifiableLayer implements
                 .filter(timeSource == TimeSource.EXIFGPSTIME ? GpxImageEntry::hasExifGpsTime : GpxImageEntry::hasExifTime)
                 .filter(e -> e.getExifCoor() == null || exif)
                 .filter(e -> tagged || !e.isTagged() || e.getExifCoor() != null)
-                .sorted(timeSource == TimeSource.EXIFGPSTIME 
-                    ? Comparator.comparing(ImageEntry::getExifGpsInstant) 
+                .sorted(timeSource == TimeSource.EXIFGPSTIME
+                    ? Comparator.comparing(ImageEntry::getExifGpsInstant)
                     : Comparator.comparing(ImageEntry::getExifInstant))
                 .collect(toList());
     }

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/GeoImageLayer.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/GeoImageLayer.java
@@ -47,6 +47,7 @@ import org.openstreetmap.josm.data.ImageData.ImageDataUpdateListener;
 import org.openstreetmap.josm.data.gpx.GpxData;
 import org.openstreetmap.josm.data.gpx.GpxImageEntry;
 import org.openstreetmap.josm.data.gpx.GpxTrack;
+import org.openstreetmap.josm.data.gpx.TimeSource;
 import org.openstreetmap.josm.data.imagery.street_level.IImageEntry;
 import org.openstreetmap.josm.data.osm.visitor.BoundingXYVisitor;
 import org.openstreetmap.josm.data.preferences.NamedColorProperty;
@@ -981,12 +982,14 @@ public class GeoImageLayer extends AbstractModifiableLayer implements
      * @return matching images
      * @since xxx gpsTime was added
      */
-    List<ImageEntry> getSortedImgList(boolean exif, boolean tagged, boolean gpsTime) {
+    List<ImageEntry> getSortedImgList(boolean exif, boolean tagged, TimeSource timeSource) {
         return data.getImages().stream()
-                .filter(gpsTime ? GpxImageEntry::hasExifGpsTime : GpxImageEntry::hasExifTime)
+                .filter(timeSource == TimeSource.EXIFGPSTIME ? GpxImageEntry::hasExifGpsTime : GpxImageEntry::hasExifTime)
                 .filter(e -> e.getExifCoor() == null || exif)
                 .filter(e -> tagged || !e.isTagged() || e.getExifCoor() != null)
-                .sorted(gpsTime ? Comparator.comparing(ImageEntry::getExifGpsInstant) : Comparator.comparing(ImageEntry::getExifInstant))
+                .sorted(timeSource == TimeSource.EXIFGPSTIME 
+                    ? Comparator.comparing(ImageEntry::getExifGpsInstant) 
+                    : Comparator.comparing(ImageEntry::getExifInstant))
                 .collect(toList());
     }
 }

--- a/src/org/openstreetmap/josm/gui/layer/geoimage/GeoImageLayer.java
+++ b/src/org/openstreetmap/josm/gui/layer/geoimage/GeoImageLayer.java
@@ -977,14 +977,16 @@ public class GeoImageLayer extends AbstractModifiableLayer implements
      * Default setting is to return untagged images, but may be overwritten.
      * @param exif also returns images with exif-gps info
      * @param tagged also returns tagged images
+     * @param gpsTime use GPS Time if true, instead of Camera RTC Time
      * @return matching images
+     * @since xxx gpsTime was added
      */
-    List<ImageEntry> getSortedImgList(boolean exif, boolean tagged) {
+    List<ImageEntry> getSortedImgList(boolean exif, boolean tagged, boolean gpsTime) {
         return data.getImages().stream()
-                .filter(GpxImageEntry::hasExifTime)
+                .filter(gpsTime ? GpxImageEntry::hasExifGpsTime : GpxImageEntry::hasExifTime)
                 .filter(e -> e.getExifCoor() == null || exif)
                 .filter(e -> tagged || !e.isTagged() || e.getExifCoor() != null)
-                .sorted(Comparator.comparing(ImageEntry::getExifInstant))
+                .sorted(gpsTime ? Comparator.comparing(ImageEntry::getExifGpsInstant) : Comparator.comparing(ImageEntry::getExifInstant))
                 .collect(toList());
     }
 }

--- a/test/unit/org/openstreetmap/josm/gui/layer/geoimage/GeoImageLayerTest.java
+++ b/test/unit/org/openstreetmap/josm/gui/layer/geoimage/GeoImageLayerTest.java
@@ -50,7 +50,7 @@ class GeoImageLayerTest {
      * Test that {@link GeoImageLayer#getSortedImgList} filters images without ExifGpsTime
      */
     @Test
-    void testMissingGPSTimeStamp(){
+    void testMissingGPSTimeStamp() {
         ImageEntry i1, i2;
         i1 = new ImageEntry();
         i1.setExifGpsTime(DateUtils.parseInstant("2016:01:03 12:00:00"));
@@ -58,7 +58,7 @@ class GeoImageLayerTest {
         i2.setExifTime(DateUtils.parseInstant("2016:01:03 12:00:01"));
 
         GeoImageLayer geoGpsImageLayer = new GeoImageLayer(Arrays.asList(i1, i2), null);
-        assertEquals(1, geoGpsImageLayer.getSortedImgList(false, false, TimeSource.EXIFGPSTIME ).size());
+        assertEquals(1, geoGpsImageLayer.getSortedImgList(false, false, TimeSource.EXIFGPSTIME).size());
     }
 
 }

--- a/test/unit/org/openstreetmap/josm/gui/layer/geoimage/GeoImageLayerTest.java
+++ b/test/unit/org/openstreetmap/josm/gui/layer/geoimage/GeoImageLayerTest.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.openstreetmap.josm.data.gpx.TimeSource;
 import org.openstreetmap.josm.data.osm.DataSet;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 import org.openstreetmap.josm.testutils.annotations.BasicPreferences;
@@ -45,6 +46,9 @@ class GeoImageLayerTest {
         assertThrows(IllegalArgumentException.class, () -> geoImageLayer.mergeFrom(osmDataLayer));
     }
 
+    /**
+     * Test that {@link GeoImageLayer#getSortedImgList} filters images without ExifGpsTime
+     */
     @Test
     void testMissingGPSTimeStamp(){
         ImageEntry i1, i2;
@@ -54,7 +58,7 @@ class GeoImageLayerTest {
         i2.setExifTime(DateUtils.parseInstant("2016:01:03 12:00:01"));
 
         GeoImageLayer geoGpsImageLayer = new GeoImageLayer(Arrays.asList(i1, i2), null);
-        assertEquals(1, geoGpsImageLayer.getSortedImgList(false, false, true).size());
+        assertEquals(1, geoGpsImageLayer.getSortedImgList(false, false, TimeSource.EXIFGPSTIME ).size());
     }
 
 }

--- a/test/unit/org/openstreetmap/josm/gui/layer/geoimage/GeoImageLayerTest.java
+++ b/test/unit/org/openstreetmap/josm/gui/layer/geoimage/GeoImageLayerTest.java
@@ -2,7 +2,9 @@
 package org.openstreetmap.josm.gui.layer.geoimage;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.jupiter.api.AfterEach;
@@ -12,6 +14,7 @@ import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 import org.openstreetmap.josm.testutils.annotations.BasicPreferences;
 import org.openstreetmap.josm.testutils.annotations.Main;
 import org.openstreetmap.josm.testutils.annotations.ThreadSync;
+import org.openstreetmap.josm.tools.date.DateUtils;
 
 /**
  * Unit tests of {@link GeoImageLayer} class.
@@ -41,4 +44,17 @@ class GeoImageLayerTest {
         OsmDataLayer osmDataLayer = new OsmDataLayer(new DataSet(), "", null);
         assertThrows(IllegalArgumentException.class, () -> geoImageLayer.mergeFrom(osmDataLayer));
     }
+
+    @Test
+    void testMissingGPSTimeStamp(){
+        ImageEntry i1, i2;
+        i1 = new ImageEntry();
+        i1.setExifGpsTime(DateUtils.parseInstant("2016:01:03 12:00:00"));
+        i2 = new ImageEntry();
+        i2.setExifTime(DateUtils.parseInstant("2016:01:03 12:00:01"));
+
+        GeoImageLayer geoGpsImageLayer = new GeoImageLayer(Arrays.asList(i1, i2), null);
+        assertEquals(1, geoGpsImageLayer.getSortedImgList(false, false, true).size());
+    }
+
 }


### PR DESCRIPTION
When you want to correlate images with gpx, with the gps clock, if some images doesn't contain the exif gps time, it crashes.
This PR filter the images list to include only images with the needed metadata.